### PR TITLE
Upgrade typepy to v1.3.0, drop Python 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,12 @@ jobs:
   test_python3:
     docker:
       - image: circleci/python:3
-
     steps:
       - checkout
       - run:
           name: test package
           command: make test
 
-  test_python2:
-    docker:
-      - image: circleci/python:2
-
-    steps:
-      - checkout
-      - run:
-          name: test package
-          command: make test
   dist_release:
     docker:
       - image: circleci/python:3
@@ -38,17 +28,12 @@ workflows:
   version: 2
   test_and_dist:
     jobs:
-      - test_python2:
-          filters:
-            tags:
-              only: /.*/
       - test_python3:
           filters:
             tags:
               only: /.*/
       - dist_release:
           requires:
-            - test_python2
             - test_python3
           filters:
             tags:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 3.4, 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/ekini/typed_environment_configuration/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # typed_environment_configuration documentation build configuration file, created by
 # sphinx-quickstart on Fri Jun  9 13:47:02 2017.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """The setup script."""
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-"typepy==0.2.5"
+"typepy==1.3.0"
 ]
 
 setup_requirements = [ ]
@@ -27,8 +27,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -47,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/springload/typed_environment_configuration',
-    version='0.1.4',
+    version='0.1.5',
     zip_safe=False,
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 """Unit test package for typed_environment_configuration."""

--- a/tests/test_typed_environment_configuration.py
+++ b/tests/test_typed_environment_configuration.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """Tests for `typed_environment_configuration` package."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py34, py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
     3.4: py34
-    2.7: py27
 
 [testenv:flake8]
 basepython = python

--- a/typed_environment_configuration/__init__.py
+++ b/typed_environment_configuration/__init__.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
-
 """Top-level package for Typed Environment Configuration."""
 
 __author__ = """Eugene Dementyev"""
 __email__ = "eugene@springload.co.nz"
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 from .typed_environment_configuration import *

--- a/typed_environment_configuration/typed_environment_configuration.py
+++ b/typed_environment_configuration/typed_environment_configuration.py
@@ -59,7 +59,7 @@ class StringEnvListVariable(typepy.type.List):
         return typepy.checker.StringTypeChecker(self._data, self._strict_level)
 
     def _create_type_converter(self):
-        return EnvListConverter(self._data)
+        return EnvListConverter(self._data, self._params)
 
 
 class BoolVariable(Variable):

--- a/typed_environment_configuration/typed_environment_configuration.py
+++ b/typed_environment_configuration/typed_environment_configuration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from os import getenv
 import typepy
 
@@ -30,7 +28,7 @@ class Variable(object):
 
         try:
             return self._value_type(value, strict_level=self._strict_level).convert()
-        except typepy._error.TypeConversionError:
+        except typepy.error.TypeConversionError:
             raise ValueError(
                 "Can't convert variable '{}' with value '{}' to type '{}'".format(
                     self._real_name, value, repr(self._value_type)
@@ -51,7 +49,7 @@ class EnvListConverter(typepy.converter.ListConverter):
                 (x.strip() for x in (self._value.split(",")) if x and x.strip())
             )
         except (TypeError, ValueError):
-            raise TypeConversionError(
+            raise typepy.error.TypeConversionError(
                 "failed to force_convert to list: type={}".format(type(self._value))
             )
 


### PR DESCRIPTION
- Upgrade [typepy](https://github.com/thombashi/typepy) dependency to `1.3.0`.
- Drop support for Python 2 (as it is no longer supported by `typepy>=1.0.0`).
- Update `typed_environment_configuration` package version to `0.1.5`.