### PR TITLE
Populate history and use tox for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test_python3:
     docker:
-      - image: circleci/python:3
+      - image: fkrull/multi-python:latest
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: test package
-          command: make test
+          command: make test-all
 
   dist_release:
     docker:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@
 
 language: python
 python:
+  - 3.10
+  - 3.9
+  - 3.8
+  - 3.7
   - 3.6
   - 3.5
   - 3.4
-  - 2.7
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
 
 # Command to run tests, e.g. python setup.py test
 script: tox
-
-

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,8 +5,10 @@ History
 0.1.6 (dev)
 ------------------
 * Update history based on git
-* Add python versions 3.6+ to test set
+* Add python versions 3.6-3.9 to test set
+* Remove python 3.4 and 3.5 from test set
 * Update circleci to run tests across all tox versions
+* Move circleci to use a multi-python docker image
 
 0.1.5 (2022-07-11)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,40 @@
 History
 =======
 
+0.1.6 (dev)
+------------------
+* Update history based on git
+* Add python versions 3.6+ to test set
+* Update circleci to run tests across all tox versions
+
+0.1.5 (2022-07-11)
+------------------
+
+* Upgrade typepy dependency to 1.3.0.
+* Drop support for Python 2 (as it is no longer supported by typepy>=1.0.0).
+
+0.1.4 2021-10-13
+------------------
+
+* Add IntegerVariable
+* Update README.rst
+* Properly fix the circleci tags build
+
+0.1.3 2018-10-17
+------------------
+
+* Fix repository url in setup.py
+
+0.1.2 2018-10-17
+------------------
+
+* Update build badge to CircleCI
+
+0.1.1 2018-10-16
+------------------
+
+* Add circleci config
+
 0.1.0 (2018-10-11)
 ------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, py310, flake8
+envlist = py36, py37, py38, py39, flake8
 
 [travis]
 python =
-    3.10: py310
     3.9: py39
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv:flake8]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, flake8
+envlist = py36, py37, py38, py39
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py34, py35, py36, flake8
+envlist = py34, py35, py36, py37, py38, py39, py310, flake8
 
 [travis]
 python =
+    3.10: py310
+    3.9: py39
+    3.8: py38
+    3.7: py37
     3.6: py36
     3.5: py35
     3.4: py34
@@ -17,4 +21,3 @@ setenv =
     PYTHONPATH = {toxinidir}
 
 commands = python setup.py test
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37, py38, py39, py310, flake8
+envlist = py35, py36, py37, py38, py39, py310, flake8
 
 [travis]
 python =
@@ -9,7 +9,6 @@ python =
     3.7: py37
     3.6: py36
     3.5: py35
-    3.4: py34
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
We had a history file, but it hadn't been updated since the first release.

We also had a tox config, but weren't really set up to use it, because
a) the circleci python image only has one python version at a time; and
b) it was configured with mostly ancient versions of python